### PR TITLE
build: :package: 优化 Vite node_modules 打包

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ lerna-debug.log*
 # Zip
 *.zip
 *.rar
+
+# Generated files
+stats.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ pnpm-lock.yaml
 
 apps/admin/@types/auto-imports.d.ts
 apps/admin/src/routeTree.gen.ts
+apps/admin/stats.html

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ pnpm dev:admin    # 启动 2F 管理系统
 pnpm dev:shopping # 启动 2F 商城
 pnpm dev:mock     # 启动 2F Mock 服务
 ```
+
+## 部署
+
+### Staging
+
+```bash
+pnpm i
+VITE_BASIC_AUTH_CODE=$xxx VITE_BASE_API_PREFIX=/base-api pnpm build:admin:staging
+```
+
+生成的 dist 包位于 /apps/admin/dist。

--- a/apps/admin/.env.staging
+++ b/apps/admin/.env.staging
@@ -1,0 +1,12 @@
+# 启动端口
+VITE_PORT=4077
+# 接口前缀
+VITE_BASE_API_PREFIX=/base-api
+# 接口地址
+VITE_BASE_API_URL=http://192.168.2.232:10000
+# Mock 接口前缀
+VITE_MOCK_API_PREFIX=/mock-api
+# Mock 接口地址
+VITE_MOCK_API_URL=https://mock.apifox.cn/
+# Basic Authorization
+VITE_BASIC_AUTH_CODE=cmFpcGlvdDpyYWlwaW90X3NlY3JldA==

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -68,6 +68,7 @@
     "cypress": "^13.6.4",
     "cypress-vite": "^1.5.0",
     "postcss": "^8.4.35",
+    "rollup-plugin-visualizer": "^5.12.0",
     "sass": "^1.71.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -5,6 +5,7 @@ import { AntdResolver, RaipiotAntdResolver, reactPresets } from '@raipiot-infra/
 import { BootstrapAnimation } from '@raipiot-infra/bootstrap-animation'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import React from '@vitejs/plugin-react-swc'
+import { visualizer } from 'rollup-plugin-visualizer'
 import AutoImport from 'unplugin-auto-import/vite'
 import IconsResolver from 'unplugin-icons/resolver'
 import Icons from 'unplugin-icons/vite'
@@ -97,6 +98,7 @@ export default defineConfig(({ mode }) => {
       TurboConsole(),
       Info(),
       WebfontDownload(),
+      visualizer({ open: false, gzipSize: true }),
       ViteCompression({
         verbose: true, // 是否在控制台中输出压缩结果
         disable: true,
@@ -132,10 +134,21 @@ export default defineConfig(({ mode }) => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks: {
-            // axios: ['axios'],
-            // antd: ['antd'],
-            // 'lodash-es': ['lodash-es']
+          // 优化 node_modules 打包
+          manualChunks(id) {
+            try {
+              if (id.includes('node_modules')) {
+                const name = id.split('node_modules/')[1].split('/')
+                if (name[0] === '.pnpm') {
+                  return name[1]
+                }
+                return name[0]
+              }
+              return undefined
+            } catch (e) {
+              process.stdout.write(e)
+              return undefined
+            }
           }
         }
       }

--- a/packages/cspell/cspell-ext.json
+++ b/packages/cspell/cspell-ext.json
@@ -21,5 +21,6 @@
       "dictionaries": ["temp"],
       "dictionaryDefinitions": []
     }
-  ]
+  ],
+  "ignorePaths": ["**/stats.html"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       postcss:
         specifier: ^8.4.35
         version: 8.4.35
+      rollup-plugin-visualizer:
+        specifier: ^5.12.0
+        version: 5.12.0
       sass:
         specifier: ^1.71.0
         version: 1.71.0
@@ -5647,6 +5650,11 @@ packages:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
+  /define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+    dev: true
+
   /define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -7566,6 +7574,12 @@ packages:
       has-tostringtag: 1.0.0
     dev: true
 
+  /is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: true
+
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7783,6 +7797,13 @@ packages:
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
     dev: true
 
   /is-wsl@3.1.0:
@@ -9255,6 +9276,15 @@ packages:
       is-wsl: 3.1.0
     dev: true
 
+  /open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: true
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -10571,6 +10601,22 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.3.10
+    dev: true
+
+  /rollup-plugin-visualizer@5.12.0:
+    resolution: {integrity: sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      source-map: 0.7.4
+      yargs: 17.7.2
     dev: true
 
   /rollup@4.9.6:


### PR DESCRIPTION
- 添加 `rollup-plugin-visualizer` 用于查看构建资源 chunk 图表，生成 /apps/admin/stats.html
![image](https://github.com/raipiot/raipiot-2f/assets/62941121/bddcf02e-6deb-40cd-be25-6f4c6e5f14a8)
- 优化 Vite node_modules 打包策略，代码分割
优化前：
![image](https://github.com/raipiot/raipiot-2f/assets/62941121/9d766a7f-2026-4299-8e70-31b0867964f9)
优化后：
![image](https://github.com/raipiot/raipiot-2f/assets/62941121/a98e15de-3939-43a2-95a3-e7ebcc3f1a20)
